### PR TITLE
Set default params for pipe via method and step overriding defaults.

### DIFF
--- a/version0/ci_pipe/pipeline.py
+++ b/version0/ci_pipe/pipeline.py
@@ -4,11 +4,14 @@ class CIPipe:
     def __init__(self, inputs):
         self._pipeline_inputs = inputs
         self._steps = []
+        # TODO: read from file? here or ISX?
+        self._defaults = {}
 
     def output(self):
         return self.next_step_input()
 
     def step(self, step_name, step_function, *args, **kwargs):
+        kwargs = {**self._defaults, **kwargs}
         new_step = Step(step_name, self.next_step_input(), self.look_up_input, step_function, args, kwargs)
         self._steps.append(new_step)
         return self
@@ -33,5 +36,14 @@ class CIPipe:
         return {
             "steps": [step.info() for step in self._steps],
             "inputs": self._pipeline_inputs,
-            "output": self.output()
+            "output": self.output(),
+            "defaults": self._defaults
         }
+
+    def set_defaults(self, **defaults):
+        self._load_defaults(defaults)
+        return self
+
+    def _load_defaults(self, defaults):
+        for defaults_key, defaults_value in defaults.items():
+            self._defaults[defaults_key] = defaults_value


### PR DESCRIPTION
# Merge Request

## Description

Default param dictionary for CIPipe using method 

```python
(CIPipe()
.set_defaults({
    'factor': 5
}))
```

Summary of changes

## Type of change

- [ ] New feature
